### PR TITLE
Add ability to configure php extension dependencies

### DIFF
--- a/example-config.php
+++ b/example-config.php
@@ -44,5 +44,14 @@ return array(
 //PHP min/max fields for Connect.  I don't know if anyone uses these, but you should
 //probably check that they're accurate
 'php_min'                => '5.2.0',
-'php_max'                => '6.0.0'
+'php_max'                => '6.0.0',
+
+//PHP extension dependencies. An array containing one or more of either:
+//  - a single string (the name of the extension dependency); use this if the
+//    extension version does not matter
+//  - an associative array with 'name', 'min', and 'max' keys which correspond
+//    to the extension's name and min/max required versions
+//Example:
+//    array('json', array('name' => 'mongo', 'min' => '1.3.0', 'max' => '1.4.0'))
+'extensions'             => array()
 );

--- a/magento-tar-to-connect.php
+++ b/magento-tar-to-connect.php
@@ -101,8 +101,24 @@ function create_package_xml($files, $base_dir, $config)
     $php                = $required->addChild('php');
     $php->min           = $config['php_min'];   //'5.2.0';
     $php->max           = $config['php_max'];   //'6.0.0';
-    
-    $node = $xml->addChild('contents');		
+
+    // add php extension dependencies
+    if (is_array($config['extensions'])) {
+        foreach ($config['extensions'] as $extinfo) {
+            $extension = $required->addChild('extension');
+            if (is_array($extinfo)) {
+                $extension->name = $extinfo['name'];
+                $extension->min = isset($extinfo['min']) ? $extinfo['min'] : "";
+                $extension->max = isset($extinfo['max']) ? $extinfo['max'] : "";
+            } else {
+                $extension->name = $extinfo;
+                $extension->min = "";
+                $extension->max = "";
+            }
+        }
+    }
+
+    $node = $xml->addChild('contents');
     $node = $node->addChild('target');
     $node->addAttribute('name', 'mage');
     


### PR DESCRIPTION
The Magento Connect packager utility allows for configuring the required PHP extension dependencies. However, this was missing from the MagentoTarToConnect utility.
