### PR TITLE
Fix cp parameter quoting

### DIFF
--- a/magento-tar-to-connect.php
+++ b/magento-tar-to-connect.php
@@ -440,7 +440,7 @@ class Pulsestorm_MagentoTarToConnect
         $extensionFileName = $extensionPath . $config['extension_name'] . '.xml';
         file_put_contents($extensionFileName, self::buildExtensionXml($files, $config));
         
-        shell_exec("cp -Rf '" . $tempDir . DIRECTORY_SEPARATOR . "var " . $path_output . "'");
+        shell_exec("cp -Rf '" . $tempDir . DIRECTORY_SEPARATOR . "var' '" . $path_output . "'");
     }
     static public function buildExtensionXml($files, $config)
     {


### PR DESCRIPTION
The CP command from previous commit fails due to quoting the pair of parameters together.